### PR TITLE
Corrected typos

### DIFF
--- a/chain/bitcoincash/address.go
+++ b/chain/bitcoincash/address.go
@@ -104,9 +104,9 @@ func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAd
 		case *btcutil.AddressPubKeyHash, *btcutil.AddressScriptHash, *btcutil.AddressPubKey:
 			return decodeLegacyAddress(addr, decoder.params)
 		case *btcutil.AddressWitnessPubKeyHash, *btcutil.AddressWitnessScriptHash:
-			return nil, fmt.Errorf("unsuported segwit bitcoin address type %T", legacyAddr)
+			return nil, fmt.Errorf("unsupported segwit bitcoin address type %T", legacyAddr)
 		default:
-			return nil, fmt.Errorf("unsuported legacy bitcoin address type %T", legacyAddr)
+			return nil, fmt.Errorf("unsupported legacy bitcoin address type %T", legacyAddr)
 		}
 	}
 

--- a/chain/bitcoincash/utxo.go
+++ b/chain/bitcoincash/utxo.go
@@ -296,7 +296,7 @@ func CalculateBip143Sighash(subScript []byte, sigHashes *txscript.TxSigHashes, h
 	sigHash.Write(bSequence[:])
 
 	// If the current signature mode isn't single, or none, then we can
-	// re-use the pre-generated hashoutputs sighash fragment. Otherwise,
+	// reuse the pre-generated hashoutputs sighash fragment. Otherwise,
 	// we'll serialize and add only the target output index to the signature
 	// pre-image.
 	if hashType&SighashMask != txscript.SigHashSingle &&

--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -85,7 +85,7 @@ func (client *Client) Tx(ctx context.Context, txID pack.Bytes) (account.Tx, pack
 
 	receipt, err := client.EthClient.TransactionReceipt(ctx, common.BytesToHash(txID))
 	if err != nil {
-		return nil, pack.NewU64(0), fmt.Errorf("fetching recipt for tx %v : %v", txID, err)
+		return nil, pack.NewU64(0), fmt.Errorf("fetching receipt, recipe for tx %v : %v", txID, err)
 	}
 
 	if receipt == nil {
@@ -95,7 +95,7 @@ func (client *Client) Tx(ctx context.Context, txID pack.Bytes) (account.Tx, pack
 
 	if receipt.Status == 0 {
 		// Transaction has been reverted.
-		return nil, pack.NewU64(0), fmt.Errorf("tx %v reverted, reciept status 0", txID)
+		return nil, pack.NewU64(0), fmt.Errorf("tx %v reverted, receipt status 0", txID)
 	}
 
 	// Transaction has been confirmed.

--- a/chain/substrate/address.go
+++ b/chain/substrate/address.go
@@ -19,7 +19,7 @@ type AddressDecoder interface {
 
 type addressDecoder struct{}
 
-// NewAddressDecoder returns the default AddressDecoder for Substract chains. It
+// NewAddressDecoder returns the default AddressDecoder for Subtract chains. It
 // uses the Bitcoin base58 alphabet to decode the string, and interprets the
 // result as a 2-byte address type, 32-byte array, and 1-byte checksum.
 func NewAddressDecoder() AddressDecoder {

--- a/chain/zcash/utxo.go
+++ b/chain/zcash/utxo.go
@@ -385,7 +385,7 @@ func calculateSighash(
 
 	// << hashOutputs
 	// If the current signature mode isn't single, or none, then we can
-	// re-use the pre-generated hashoutputs sighash fragment. Otherwise,
+	// reuse the pre-generated hashoutputs sighash fragment. Otherwise,
 	// we'll serialize and add only the target output index to the signature
 	// pre-image.
 	if hashType&sighashMask != txscript.SigHashSingle && hashType&sighashMask != txscript.SigHashNone {
@@ -527,9 +527,9 @@ func txSighashes(tx *wire.MsgTx) (h *txscript.TxSigHashes, err error) {
 
 // calculateHashPrevOuts calculates a single hash of all the previous
 // outputs (txid:index) referenced within the passed transaction. This
-// calculated hash can be re-used when validating all inputs spending segwit
+// calculated hash can be reused when validating all inputs spending segwit
 // outputs, with a signature hash type of SigHashAll. This allows validation to
-// re-use previous hashing computation, reducing the complexity of validating
+// reuse previous hashing computation, reducing the complexity of validating
 // SigHashAll inputs from  O(N^2) to O(N).
 func calculateHashPrevOuts(tx *wire.MsgTx) (chainhash.Hash, error) {
 	var b bytes.Buffer
@@ -551,9 +551,9 @@ func calculateHashPrevOuts(tx *wire.MsgTx) (chainhash.Hash, error) {
 
 // calculateHashSequence computes an aggregated hash of each of the
 // sequence numbers within the inputs of the passed transaction. This single
-// hash can be re-used when validating all inputs spending segwit outputs, which
+// hash can be reused when validating all inputs spending segwit outputs, which
 // include signatures using the SigHashAll sighash type. This allows validation
-// to re-use previous hashing computation, reducing the complexity of validating
+// to reuse previous hashing computation, reducing the complexity of validating
 // SigHashAll inputs from O(N^2) to O(N).
 func calculateHashSequence(tx *wire.MsgTx) (chainhash.Hash, error) {
 	var b bytes.Buffer
@@ -568,7 +568,7 @@ func calculateHashSequence(tx *wire.MsgTx) (chainhash.Hash, error) {
 
 // calculateHashOutputs computes a hash digest of all outputs created by
 // the transaction encoded using the wire format. This single hash can be
-// re-used when validating all inputs spending witness programs, which include
+// reused when validating all inputs spending witness programs, which include
 // signatures using the SigHashAll sighash type. This allows computation to be
 // cached, reducing the total hashing complexity from O(N^2) to O(N).
 func calculateHashOutputs(tx *wire.MsgTx) (_ chainhash.Hash, err error) {


### PR DESCRIPTION
Changes made in:

- /chain/bitcoincash/address.go ("unsuported" → "unsupported")

- /chain/bitcoincash/address.go ("unsuported" → "unsupported")

- /chain/bitcoincash/utxo.go ("re-use" → "reuse")

- /chain/zcash/utxo.go ("re-use" → "reuse")

- /chain/zcash/utxo.go ("re-use" → "reuse")

- /chain/substrate/address.go ("Substract" → "Subtract")

- /chain/evm/client.go ("recipt" → "receipt, recipe")

- /chain/evm/client.go ("reciept" → "receipt")
